### PR TITLE
drop minimum support for ruby to 2.5

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 2.5
   NewCops: enable
 
 Style/MultilineBlockChain:

--- a/dryspec.gemspec
+++ b/dryspec.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description   = 'A Ruby gem to introduce RSpec helpers which can help you DRY up your specs'
   spec.homepage      = 'https://github.com/northwoodspd/dryspec'
   spec.license       = 'MIT'
-  spec.required_ruby_version = '>= 2.7.0'
+  spec.required_ruby_version = '>= 2.5.0'
 
   spec.files = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})


### PR DESCRIPTION
After talking with the team, we felt it was important to stay compatible with ruby 2.5